### PR TITLE
Erklärung => Selbstständigkeitserklärung

### DIFF
--- a/content/01_disclaimer.tex
+++ b/content/01_disclaimer.tex
@@ -2,7 +2,7 @@
 \selectlanguage{ngerman}
 
 \section*{\vfill{} \thispagestyle{empty}
-Erklärung}
+Selbständigkeitserklärung}
 
 Hiermit erkläre ich, dass ich diese Arbeit selbstständig erstellt
 und keine anderen als die angegebenen Hilfsmittel benutzt habe.


### PR DESCRIPTION
Dieser Fehler ist seit Jahren im Template und hat sich dadurch in viele Abschlussarbeiten eingeschlichen. 
Ich möchte auf niemanden mit dem Finger zeigen und verzichte daher auf direkte Links :) Aber auf https://os.inf.tu-dresden.de/papers_ps/ findet man zahlreiche Abgaben mit diesem Fehler.

**TL;DR: Der allgemein anerkannte Begriff lautet Selbstständigkeitserklärung**