### PR TITLE
make headings look more professional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ einige Hintergrundinformationen.
   *"Set A contains elements a, b, and c."*
 - more stylistic information can be found in *Bugs in writing* (BIW)
   by Lyn Dupré
+- add chapters without a chapter number (e.g. appendix) with `\addchap{Chapter without Number}`
+  instead of `\chapter*{Chapter without Number}`. Otherwise, `\chaptername` and similar macros
+  inherit the name of the last chapter with a number in several cases.
+  `\addchap` is a macro provided by KOMA
 
 
 spezielle Tipps von Frank

--- a/preamble/packages.tex
+++ b/preamble/packages.tex
@@ -18,6 +18,9 @@
 \usepackage{todonotes}
 \usepackage{xspace}
 \usepackage{setspace}
+\usepackage{fancyhdr}           % enables cool header line and footer line manipulations
+\usepackage{lastpage}           % enables the usage of the label "LastPage" to get the
+                                % number of pages with \pageref{LastPage}
 
 % use this one last
 % (redefines some macros for compatibility with KOMAScript)

--- a/preamble/style.tex
+++ b/preamble/style.tex
@@ -47,3 +47,33 @@
 
 % use nice footnote indentation
 \deffootnote[1em]{1em}{1em}{\textsuperscript{\thefootnotemark}\,}
+
+% ########################################################
+
+% - Roman/Serif font for all headings.
+%   Default is sans-serif which looks kind of unprofessional with the default font family.
+% - Packages like titlesec don't work well together with KOMA
+% - "disposition" means, that this setting is for all headings (chapter level, section level, ...)
+%   see: https://mirror.physik.tu-berlin.de/pub/CTAN/macros/latex/contrib/koma-script/doc/scrguide.pdf
+\addtokomafont{disposition}{\rmfamily}
+
+% ########################################################
+% With the fancyhdr package we can let all pages look more professional.
+% Each page (except for special ones such as chapters or the cover) will contain a
+% header that looks like this:
+%
+% Chapter %NUM%. %CHAPTER_NAME%                                                      3/10
+% ---------------------------------------------------------------------------------------
+\pagestyle{fancy}% muss vor \renewcommand{\sectionmark} stehen
+% Reset all styles
+\fancyhf{}
+% Show the chapter name
+% even left, odd left: Put the chapter name always on the top left.
+% Content behind "\leftmark" can get configured. See package documentation.
+% By default it produces: "Chapter %NUM%. %CHAPTER NAME%"
+\fancyhead[EL,OL]{\leftmark}
+% Page number on the right in the fancy header line.
+% Label "LastPage" works because of the "lastpage" package
+\fancyhead[ER,OR]{\thepage~/~\pageref{LastPage}}
+% Page number on the bottom
+\fancyfoot[EC,OC]{\thepage}

--- a/preamble/style.tex
+++ b/preamble/style.tex
@@ -63,17 +63,25 @@
 % header that looks like this:
 %
 % Chapter %NUM%. %CHAPTER_NAME%                                                      3/10
-% ---------------------------------------------------------------------------------------
-\pagestyle{fancy}% muss vor \renewcommand{\sectionmark} stehen
-% Reset all styles
+%
+% On even pages the page number is on the left, on odd pages the page number is on the right.
+%
+\pagestyle{fancy}
+% Reset all existing header styles
 \fancyhf{}
-% Show the chapter name
-% even left, odd left: Put the chapter name always on the top left.
-% Content behind "\leftmark" can get configured. See package documentation.
-% By default it produces: "Chapter %NUM%. %CHAPTER NAME%"
-\fancyhead[EL,OL]{\leftmark}
-% Page number on the right in the fancy header line.
-% Label "LastPage" works because of the "lastpage" package
-\fancyhead[ER,OR]{\thepage~/~\pageref{LastPage}}
-% Page number on the bottom
-\fancyfoot[EC,OC]{\thepage}
+
+% Even pages (Ex)
+% EL: even left: show page number
+\fancyhead[EL]{\thepage~/~\pageref{LastPage}}
+% ER: even right: show chapter
+\fancyhead[ER]{\leftmark}
+
+% Odd pages (Ox)
+% OL: odd left: show page number
+\fancyhead[OR]{\thepage~/~\pageref{LastPage}}
+% OR: odd right: show chapter
+\fancyhead[OL]{\rightmark}
+
+
+% Additionally page number always on the bottom
+% \fancyfoot[EC,OC]{\thepage}


### PR DESCRIPTION
Style is of course an opinion. However, I think these small changes make the thesis look much more professional. Furthermore,
if someone doesn't want it, it can be easily removed.


What do you think?


## Before (Heading)
![image](https://user-images.githubusercontent.com/5737016/153640172-821832b3-18bc-41bd-9bd4-90c356a0816e.png)

## After (Heading)
![image](https://user-images.githubusercontent.com/5737016/153640310-3f426317-377d-4c63-ba38-cd99a6e8a013.png)




## Before (Header)
![image](https://user-images.githubusercontent.com/5737016/153640212-0f28013d-28b9-4275-8d8d-2acef3d3d7c7.png)



## After (Header - PS: This is aware of even/odd pages. On odd pages the page number is on the right side. On even pages the page number is on the left side.)
![image](https://user-images.githubusercontent.com/5737016/159174909-d70f8836-30e1-4bf1-a817-f39b5f82e8ca.png)
