### PR TITLE
Hyperref hide links

### DIFF
--- a/diplom.tex
+++ b/diplom.tex
@@ -22,7 +22,9 @@ filebordercolor={0.75 0.75 1},
 linkbordercolor={0.75 0.75 1},
 % pagebordercolor={0.75 0.75 1},
 urlbordercolor={0.75 0.75 1},
-pdfborder={0.75 0.75 1},plainpages=false,pdfpagelabels=true]{hyperref}
+pdfborder={0.75 0.75 1},
+hidelinks,
+plainpages=false,pdfpagelabels=true]{hyperref}
 \hypersetup{%
   pdftitle={Dein Titel},
   pdfauthor={Otto Mustermann},


### PR DESCRIPTION
A small change that hides links in PDF documents. Looks ugly otherwise, TBH

**Before**
![image](https://user-images.githubusercontent.com/5737016/153641020-60abd46a-9c00-47bb-bdf8-99e4d75b2d3b.png)


**After**
![image](https://user-images.githubusercontent.com/5737016/153640906-1e032164-1e6a-47f5-b58c-2aafc3b81a62.png)
