### PR TITLE
remove odd page numbering

### DIFF
--- a/diplom.tex
+++ b/diplom.tex
@@ -45,6 +45,8 @@ pdfborder={0.75 0.75 1},plainpages=false,pdfpagelabels=true]{hyperref}
 
 \input{content/00_title.tex}
 
+\pagenumbering{arabic}
+
 \includepdf{images/diplom-aufgabe.pdf}
 \cleardoublepage
 
@@ -73,7 +75,6 @@ pdfborder={0.75 0.75 1},plainpages=false,pdfpagelabels=true]{hyperref}
 \listoftables
 \cleardoublepage
 
-\pagenumbering{arabic}
 \input{content/10_introduction.tex}
 \input{content/20_state.tex}
 \input{content/30_design.tex}


### PR DESCRIPTION
This odd behavior comes from https://github.com/TUD-OS/latex-template/commit/a3d68da998fcbe241d2b1900e23968efc241cca6 

I don't know why the roman numbering is necessary at all. Please look: this just looks confusing and odd. Much better with normal numbering.

Before:
![image](https://user-images.githubusercontent.com/5737016/153704913-88385418-850a-4c22-b336-cd2822b6fbd6.png)





After:
![image](https://user-images.githubusercontent.com/5737016/153704895-c33a892b-6aa6-4699-9a27-4619a4ca7e7f.png)
