### PR TITLE
.editorconfig + consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.tex]
+max_line_length = 100

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to use the `$ make checkbiw` script please execute: `git submodule upda
 
 Build Prerequisites
 ===================
-In case you don't want to install `texlive-full` to save disk space, the following packages are 
+In case you don't want to install `texlive-full` to save disk space, the following packages are
 actually required: \
 ```shell
 $ sudo apt install texlive-base \
@@ -25,10 +25,10 @@ $ sudo apt install texlive-base \
    biber \
    texlive-bibtex-extra \
    `# for csquotes` \
-   texlive-latex-extra   
+   texlive-latex-extra
 ```
 
-Additionally, please install also: 
+Additionally, please install also:
 ```shell
 $ sudo apt install \
   `# for the `make checkbiw` script`
@@ -110,6 +110,9 @@ einige Hintergrundinformationen.
   instead of `\chapter*{Chapter without Number}`. Otherwise, `\chaptername` and similar macros
   inherit the name of the last chapter with a number in several cases.
   `\addchap` is a macro provided by KOMA
+- this project uses a `.editorconfig` which makes sure you have the same basic formatting
+  settings across IDEs **as you type**. Support exists in Clion, VS Code, IntelliJ,
+  vim, ... make sure to activate the setting or add the plugin for that into your IDE/editor
 
 
 spezielle Tipps von Frank

--- a/content/00_title.tex
+++ b/content/00_title.tex
@@ -1,28 +1,28 @@
- 
 \selectlanguage{ngerman}
 
 \begin{singlespace}
 
-\subject{{\LARGE Diplomarbeit}}
+    \subject{{\LARGE Diplomarbeit}}
 
-\title{Dein Titel}
+    \title{Dein Titel}
 
-\author{Otto Mustermann}
+    \author{Otto Mustermann}
 
-\publishers{Technische Universität Dresden\\
-Fakultät Informatik\\
-Institut für Systemarchitektur\\
-Professur Betriebssysteme\\
-\begin{minipage}{\textwidth}%\\
-\vskip 6cm
- {\normalsize }\begin{tabular}{ll}
-Betreuender Hochschullehrer: &
-Prof. Dr. rer. nat. Hermann Härtig\tabularnewline
-Betreuender Mitarbeiter: &
-Dipl.-Inf. Dein Betreuer\tabularnewline
-\end{tabular} {\normalsize }\end{minipage}}
+    \publishers{Technische Universität Dresden\\
+    Fakultät Informatik\\
+    Institut für Systemarchitektur\\
+    Professur Betriebssysteme\\
+        \begin{minipage}{\textwidth}%\\
+            \vskip 6cm
+                {\normalsize }\begin{tabular}{ll}
+                                  Betreuender Hochschullehrer: &
+                                  Prof. Dr. rer. nat. Hermann Härtig\tabularnewline
+                                  Betreuender Mitarbeiter: &
+                                  Dipl.-Inf. Dein Betreuer\tabularnewline
+            \end{tabular} {\normalsize }
+        \end{minipage}}
 
-\maketitle
+    \maketitle
 \end{singlespace}
 
 \cleardoublepage

--- a/content/01_disclaimer.tex
+++ b/content/01_disclaimer.tex
@@ -1,4 +1,3 @@
- 
 \selectlanguage{ngerman}
 
 \section*{\vfill{} \thispagestyle{empty}

--- a/content/10_introduction.tex
+++ b/content/10_introduction.tex
@@ -25,19 +25,19 @@ Referencing other chapters: \ref{sec:state} \ref{sec:design}
 \ref{sec:conclusion}
 
 \begin{table}[htp]
-  \centering
-  \begin{tabular}{lrr}
-    \textbf{Name} & \textbf{Y} & \textbf{Z} \\
-    \hline
-    \textit{Foo} & 20,614 & \SI{23}{\percent} \\
-    \textit{Bar} & 9,914 & \SI{11}{\percent} \\
-    \textit{Foo + Bar} & 30,528 & \SI{34}{\percent} \\
-    \hline
-    \textit{total} & 88,215 & \SI{100}{\percent} \\
+    \centering
+    \begin{tabular}{lrr}
+        \textbf{Name}      & \textbf{Y} & \textbf{Z}         \\
+        \hline
+        \textit{Foo}       & 20,614     & \SI{23}{\percent}  \\
+        \textit{Bar}       & 9,914      & \SI{11}{\percent}  \\
+        \textit{Foo + Bar} & 30,528     & \SI{34}{\percent}  \\
+        \hline
+        \textit{total}     & 88,215     & \SI{100}{\percent} \\
 
-  \end{tabular}
-  \caption[Some interesting numbers]{Various very important looking numbers and sums.}
-  \label{tab:numbers}
+    \end{tabular}
+    \caption[Some interesting numbers]{Various very important looking numbers and sums.}
+    \label{tab:numbers}
 \end{table}
 
 More text referencing Table~\ref{tab:numbers}.
@@ -45,12 +45,12 @@ More text referencing Table~\ref{tab:numbers}.
 \section{Another Section}
 
 \begin{figure}[tbp]
-  \centering
-  \includegraphics[width=0.8\textwidth]{images/squirrel}
-  \caption[Short description]{A long description of this squirrel figure.
-  Image taken from
-  \url{http://commons.wikimedia.org/wiki/File:Sciurus-vulgaris_hernandeangelis_stockholm_2008-06-04.jpg}}
-  \label{fig:squirrel}
+    \centering
+    \includegraphics[width=0.8\textwidth]{images/squirrel}
+    \caption[Short description]{A long description of this squirrel figure.
+    Image taken from
+    \url{http://commons.wikimedia.org/wiki/File:Sciurus-vulgaris_hernandeangelis_stockholm_2008-06-04.jpg}}
+    \label{fig:squirrel}
 \end{figure}
 
 Citing \cite{bellard2005qfa} other documents \cite{bellard2005qfa, boileau06}
@@ -61,14 +61,15 @@ Something with umlauts and a year/month date:
 
 And some online resources: \cite{green04}, \cite{patent:4819234}
 
+
 \section{Yet Another Section}
 
 \todo{add content}
 
 \begin{figure}[tbp]
- \missingfigure{Come up with a mindblowing figure.}
- \caption{A mindblowing figure}
- \label{fig:todo}
+    \missingfigure{Come up with a mindblowing figure.}
+    \caption{A mindblowing figure}
+    \label{fig:todo}
 \end{figure}
 
 \section{Test commands}

--- a/own.bib
+++ b/own.bib
@@ -2,73 +2,73 @@
 % Encoding: UTF-8
 
 @INPROCEEDINGS{becher04:_feurig_hacken_mit_firew,
-  author = {Michael Becher and Maximillian Dornseif},
-  title = {{Feuriges Hacken - Spaß mit Firewire}},
-  booktitle = {21C3: Proceedings of the 21st Chaos Communication Congress},
-  date = {2004-12}
+    author = {Michael Becher and Maximillian Dornseif},
+    title = {{Feuriges Hacken - Spaß mit Firewire}},
+    booktitle = {21C3: Proceedings of the 21st Chaos Communication Congress},
+    date = {2004-12}
 }
 
 @CONFERENCE{bellard2005qfa,
-  author = {Fabrice Bellard},
-  title = {{QEMU, a fast and portable dynamic translator}},
-  booktitle = {Proceedings of the USENIX Annual Technical Conference, FREENIX Track},
-  date = {2005},
-  pages = {41--46}
+    author = {Fabrice Bellard},
+    title = {{QEMU, a fast and portable dynamic translator}},
+    booktitle = {Proceedings of the USENIX Annual Technical Conference, FREENIX Track},
+    date = {2005},
+    pages = {41--46}
 }
 
 @INPROCEEDINGS{boileau06,
-  author = {Adam Boileau},
-  title = {{Hit by a Bus: Physical Access Attacks with Firewire}},
-  booktitle = {RUXCON},
-  date = {2006}
+    author = {Adam Boileau},
+    title = {{Hit by a Bus: Physical Access Attacks with Firewire}},
+    booktitle = {RUXCON},
+    date = {2006}
 }
 
 @BOOK{frederick95,
-  author = {Brooks,Jr., Frederick P.},
-  title = {The mythical man-month (anniversary ed.)},
-  date = {1995},
-  publisher = {Addison-Wesley Longman Publishing Co., Inc.},
-  location = {Boston, MA, USA},
-  isbn = {0-201-83595-9}
+    author = {Brooks,Jr., Frederick P.},
+    title = {The mythical man-month (anniversary ed.)},
+    date = {1995},
+    publisher = {Addison-Wesley Longman Publishing Co., Inc.},
+    location = {Boston, MA, USA},
+    isbn = {0-201-83595-9}
 }
 
 @ARTICLE{collins97a,
-  author = {Robert R. Collins},
-  title = {{In-Circuit Emulation: How the Microprocessor Evolved Over Time}},
-  date = {1997-09},
-  journal = {Dr. Dobbs Journal}
+    author = {Robert R. Collins},
+    title = {{In-Circuit Emulation: How the Microprocessor Evolved Over Time}},
+    date = {1997-09},
+    journal = {Dr. Dobbs Journal}
 }
 
 @ARTICLE{feske07,
-  author = {Norman Feske},
-  title = {{A case study on the cost and benefit of dynamic RPC marshalling
+    author = {Norman Feske},
+    title = {{A case study on the cost and benefit of dynamic RPC marshalling
 	for low-level system components}},
-  date = {2007},
-  volume = {41},
-  number = {4},
-  pages = {40--48},
-  issn = {0163-5980},
-  doi = {http://doi.acm.org/10.1145/1278901.1278908},
-  journal = {SIGOPS Operating Systems Review},
-  location = {New York, NY, USA},
-  publisher = {ACM}
+    date = {2007},
+    volume = {41},
+    number = {4},
+    pages = {40--48},
+    issn = {0163-5980},
+    doi = {http://doi.acm.org/10.1145/1278901.1278908},
+    journal = {SIGOPS Operating Systems Review},
+    location = {New York, NY, USA},
+    publisher = {ACM}
 }
 
 @ONLINE{green04,
-  author = {Tom Green},
-  title = {{1394 Kernel Debugging Tips and Tricks}},
-  date = {2004},
-  url = {http://download.microsoft.com/download/1/8/f/18f8cee2-0b64-41f2-893d-a6f2295b40c8/DW04001_WINHEC2004.ppt},
-  note = {Slide presentation at the WinHEC 2004},
-  urldate = {2009-06-03}
+    author = {Tom Green},
+    title = {{1394 Kernel Debugging Tips and Tricks}},
+    date = {2004},
+    url = {http://download.microsoft.com/download/1/8/f/18f8cee2-0b64-41f2-893d-a6f2295b40c8/DW04001_WINHEC2004.ppt},
+    note = {Slide presentation at the WinHEC 2004},
+    urldate = {2009-06-03}
 }
 
 @PATENT{patent:4819234,
-  author = {Huber, William S.},
-  title = {Operating system debugger},
-  number = {4819234},
-  date = {1989-04},
-  location = {Needham, MA},
-  url = {http://www.freepatentsonline.com/4819234.html}
+    author = {Huber, William S.},
+    title = {Operating system debugger},
+    number = {4819234},
+    date = {1989-04},
+    location = {Needham, MA},
+    url = {http://www.freepatentsonline.com/4819234.html}
 }
 

--- a/preamble/color.tex
+++ b/preamble/color.tex
@@ -1,4 +1,3 @@
- 
 \definecolor{mygreen}{rgb}{0,0.6,0}
 \definecolor{mygray}{rgb}{0.5,0.5,0.5}
 \definecolor{mymauve}{rgb}{0.58,0,0.82}

--- a/preamble/newcommands.tex
+++ b/preamble/newcommands.tex
@@ -1,4 +1,3 @@
- 
 % some common commands
 \newcommand{\drops}{\texorpdfstring{\textsc{Drops}\xspace}{DROPS}}
 \newcommand{\LLinux}{\texorpdfstring{L$\!^4$Linux}{L4Linux}}

--- a/preamble/style.tex
+++ b/preamble/style.tex
@@ -1,4 +1,3 @@
- 
 % Biblatex Style
 \setcounter{secnumdepth}{3}     % limit enumeration depth
 \setcounter{tocdepth}{1}        % limit TOC depth
@@ -6,33 +5,33 @@
 % Listing Style
 
 \lstset{ %
-  frame=shadowbox,
-  rulesepcolor=\color{blue},
-  backgroundcolor=\color{white},   % choose the background color; you must add \usepackage{color} or \usepackage{xcolor}
-%  basicstyle=\footnotesize,        % the size of the fonts that are used for the code
-  breakatwhitespace=false,         % sets if automatic breaks should only happen at whitespace
-  breaklines=true,                 % sets automatic line breaking
-  captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{mygreen},    % comment style
-  deletekeywords={...},            % if you want to delete keywords from the given language
-  escapeinside={\%*}{*)},          % if you want to add LaTeX within your code
-  extendedchars=true,              % lets you use non-ASCII characters; for 8-bits encodings only, does not work with UTF-8
-  frame=single,                    % adds a frame around the code
-  keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code (possibly needs columns=flexible)
-  keywordstyle=\color{blue},       % keyword style
-  language=C,                 % the language of the code
- % morekeywords={*,...},            % if you want to add more keywords to the set
-  numbers=left,                    % where to put the line-numbers; possible values are (none, left, right)
-  numbersep=7pt,                   % how far the line-numbers are from the code
-  numberstyle=\tiny\color{mygray}, % the style that is used for the line-numbers
-  rulecolor=\color{black},         % if not set, the frame-color may be changed on line-breaks within not-black text (e.g. comments (green here))
-  showspaces=false,                % show spaces everywhere adding particular underscores; it overrides 'showstringspaces'
-  showstringspaces=false,          % underline spaces within strings only
-  showtabs=false,                  % show tabs within strings adding particular underscores
-  stepnumber=1,                    % the step between two line-numbers. If it's 1, each line will be numbered
-  stringstyle=\color{mymauve},     % string literal style
-  tabsize=2,                       % sets default tabsize to 2 spaces
-  title=\lstname                   % show the filename of files included with \lstinputlisting; also try caption instead of title
+    frame=shadowbox,
+    rulesepcolor=\color{blue},
+    backgroundcolor=\color{white},   % choose the background color; you must add \usepackage{color} or \usepackage{xcolor}
+    %  basicstyle=\footnotesize,        % the size of the fonts that are used for the code
+    breakatwhitespace=false,         % sets if automatic breaks should only happen at whitespace
+    breaklines=true,                 % sets automatic line breaking
+    captionpos=b,                    % sets the caption-position to bottom
+    commentstyle=\color{mygreen},    % comment style
+    deletekeywords={...},            % if you want to delete keywords from the given language
+    escapeinside={\%*}{*)},          % if you want to add LaTeX within your code
+    extendedchars=true,              % lets you use non-ASCII characters; for 8-bits encodings only, does not work with UTF-8
+    frame=single,                    % adds a frame around the code
+    keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code (possibly needs columns=flexible)
+    keywordstyle=\color{blue},       % keyword style
+    language=C,                 % the language of the code
+    % morekeywords={*,...},            % if you want to add more keywords to the set
+    numbers=left,                    % where to put the line-numbers; possible values are (none, left, right)
+    numbersep=7pt,                   % how far the line-numbers are from the code
+    numberstyle=\tiny\color{mygray}, % the style that is used for the line-numbers
+    rulecolor=\color{black},         % if not set, the frame-color may be changed on line-breaks within not-black text (e.g. comments (green here))
+    showspaces=false,                % show spaces everywhere adding particular underscores; it overrides 'showstringspaces'
+    showstringspaces=false,          % underline spaces within strings only
+    showtabs=false,                  % show tabs within strings adding particular underscores
+    stepnumber=1,                    % the step between two line-numbers. If it's 1, each line will be numbered
+    stringstyle=\color{mymauve},     % string literal style
+    tabsize=2,                       % sets default tabsize to 2 spaces
+    title=\lstname                   % show the filename of files included with \lstinputlisting; also try caption instead of title
 }
 
 % Typesetting options


### PR DESCRIPTION
As suggested in #8 I outsourced the editorconfig + formatting commits to this PR.

An `.editorconfig` file is something that every project should use today. It provides code settings for the project, such as  indentation depth, tabs or spaces etc and overrides default settings of the editor or the IDE. Every reasonable editor or IDE has built-in support or via a good plugin. 

.editorconfig also allows specifying code styles per file type. For example, "&lt;tab&gt;" will be a tab in a Makefile but 2 or 4 spaces in other files.

