### PR TITLE
comment and "test" for special chars

### DIFF
--- a/content/10_introduction.tex
+++ b/content/10_introduction.tex
@@ -77,6 +77,15 @@ And some online resources: \cite{green04}, \cite{patent:4819234}
 \texttt{memcpy}
 A sentence about BASIC. And a correctly formatted one about ECC\@.
 
+\section{Test Special Chars}
+Before you start writing your thesis please make sure that your build setup
+compiles the following special chars correctly into the PDF!
+If for example ß is printed as 'SS' then you should fix this!
+There are a few hints in the repository in \mbox{\texttt{preamble/packages.txt}}.
+
+ö ä ü Ö Ä Ü ß < >
+
+
 \cleardoublepage
 
 %%% Local Variables:

--- a/preamble/packages.tex
+++ b/preamble/packages.tex
@@ -2,6 +2,14 @@
 % Without "maxbibnames=99" the bibliography entries only contain "First Name et al."
 \usepackage[backend=biber,style=alphabetic,alldates=long,maxbibnames=99]{biblatex}
 
+% FONT SETTINGS & ENCODING
+% By default this build setup uses lualatex which supports special characters
+% (öäüß<>) out of the box. If you ever want to switch to pdflatex but also
+% keep the support for lualatex, add these three packages:
+% \usepackage[T1]{fontenc}
+% \usepackage[utf8]{luainputenc}
+% \usepackage{lmodern}
+
 \usepackage{varioref}           % nice refs
 \usepackage{csquotes}
 \usepackage{graphicx}           % graphics


### PR DESCRIPTION
Ich bin kürzlich von pdflatex zurück zu lualatex gewechselt und habevorhin festgestellt, dass bei mir Sonderzeichen kaputt waren (ß => SS). Ich denke es ist sinnvoll, dass man direkt einfach mal die Sonderzeichen mit in das Template packt, damit Leute das direkt zu Beginn bei sich überprüfen können.