### PR TITLE
"stats" target for make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ auto
 
 *.bcf
 diplom.pdf
+# comes from the "make stats" command
+diplom.pdf.txt
 *.run.xml
 *.synctex.gz
 
@@ -38,3 +40,4 @@ diplom.pdf
 
 # "make" produces PDFs in this format.
 /*DRAFT*.pdf
+


### PR DESCRIPTION
This MR adds a convenient `make stats` command with an output like this:

![image](https://user-images.githubusercontent.com/5737016/175269930-97dd2e85-128b-4733-9e48-ef5d388e7349.png)
