### PR TITLE
align orthography in disclaimer

### DIFF
--- a/content/01_disclaimer.tex
+++ b/content/01_disclaimer.tex
@@ -1,7 +1,7 @@
 \selectlanguage{ngerman}
 
 \section*{\vfill{} \thispagestyle{empty}
-Selbständigkeitserklärung}
+Selbstständigkeitserklärung}
 
 Hiermit erkläre ich, dass ich diese Arbeit selbstständig erstellt
 und keine anderen als die angegebenen Hilfsmittel benutzt habe.


### PR DESCRIPTION
In the disclaimer, both the old spelling (Selb**st**ändig..., line 4) and the new spelling (selb**stst**ändig, line 6) are used.
While both spellings are correct, it may be appropriate to ensure consistency by using one spelling throughout.